### PR TITLE
Fixing default fallback language

### DIFF
--- a/i18n/init.js
+++ b/i18n/init.js
@@ -42,6 +42,7 @@ const detection = {
 
 i18next.use(LanguageDetector).init({
 	detection: detection,
+	lng: defaultLanguage,
 	fallbackLng: defaultLanguage,
 	resources: locales,
 	ns: ['translations'],


### PR DESCRIPTION
Fallback logic seems to be referring to the 'lng' key in localStorage. Setting it to the defaultLanguage to prevent it from picking up the user's browser's default language as that may be unsupported.